### PR TITLE
Add GitHub Actions workflow for YAML linting

### DIFF
--- a/.github/workflows/tools_yaml_linter.yml
+++ b/.github/workflows/tools_yaml_linter.yml
@@ -1,0 +1,27 @@
+---
+name: "Tools - Validate YAML Schema"
+
+"on":
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - ".yamllint"
+      - "**.yaml"
+      - "**.yml"
+      - "**.yml.example"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-yaml:
+    name: YAML Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Validate YAML files
+        run: yamllint .

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+extends: default
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+  - '*.yml.example'
+
+rules:
+  empty-lines:
+    level: warning


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to lint YAML files in the repository.

### What Changed
- Introduced a new GitHub Actions workflow to validate YAML files.
- Integrated a YAML linter (e.g. yamllint) to check syntax and formatting.
- Configured the workflow to run on pull requests and/or pushes.