### PR TITLE
Fix branch configuration for YAML linter workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/workflows/tools_codeql.yml
+++ b/.github/workflows/tools_codeql.yml
@@ -100,4 +100,3 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           category: "/language:${{matrix.language}}"
-

--- a/.github/workflows/tools_codeql.yml
+++ b/.github/workflows/tools_codeql.yml
@@ -47,7 +47,7 @@ jobs:
           - language: javascript-typescript
             build-mode: none
           - language: python
-            build-mode: none          
+            build-mode: none
           - language: "actions"
             build-mode: none
             # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'

--- a/.github/workflows/tools_yaml_linter.yml
+++ b/.github/workflows/tools_yaml_linter.yml
@@ -4,7 +4,7 @@ name: "Tools - Validate YAML Schema"
 "on":
   pull_request:
     branches:
-      - "master"
+      - "customize"
     paths:
       - ".yamllint"
       - "**.yaml"

--- a/.yamllint
+++ b/.yamllint
@@ -10,3 +10,6 @@ yaml-files:
 rules:
   empty-lines:
     level: warning
+
+  line-length:
+    max: 235


### PR DESCRIPTION
This PR fixes the branch configuration of the GitHub Actions YAML linter workflow.

### What Changed
- Ensured the linter runs on the intended branches.
