### PR TITLE
Fix incorrect GitHub owner name in repository references

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ License: BSD 2-clause license (see LICENSE.txt).
 
  6. Install the application:
 	
-        $ git clone --branch Customize https://github.com/dwydler/mta-sts /var/www/html/mta-sts
+        $ git clone --branch Customize https://github.com/wydler/mta-sts /var/www/html/mta-sts
 		
 
  7. Install a montioring tool for it:

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@ mx: backupmx.example.com</pre>
 				<li>Test this mail domain using this or <a target="_blank" href="https://www.hardenize.com/">another validator</a>.</li>
 			</ul>
 			<hr>
-			<p>Created by: <a target="_blank" href="https://aykevl.nl/" rel="author">Ayke</a>. Modify by: <a target="_blank" href="https://blog.daniel.wydler.eu" rel="autor">Daniel Wydler</a> (<a target="_blank" href="https://github.com/dwydler/mta-sts">source code</a>). If you encounter any errors, you can create a <a target="_blank" href="https://github.com/dwydler/mta-sts/issues/new">Issue</a>.
+			<p>Created by: <a target="_blank" href="https://aykevl.nl/" rel="author">Ayke</a>. Modify by: <a target="_blank" href="https://blog.daniel.wydler.eu" rel="autor">Daniel Wydler</a> (<a target="_blank" href="https://github.com/wydler/mta-sts">source code</a>). If you encounter any errors, you can create a <a target="_blank" href="https://github.com/wydler/mta-sts/issues/new">Issue</a>.
 		</div>
 
 		<div id="templates">


### PR DESCRIPTION
This PR fixes incorrect GitHub owner name references in the repository configuration.

### What Changed
- Updated GitHub repository owner references to the correct namespace.
- Replaced incorrect `owner/repo` values with the proper owner name.
- Ensured consistency across all GitHub-related references (e.g. workflows, documentation, or configuration files).
